### PR TITLE
Fix phone regex in User model

### DIFF
--- a/AsyncAcademy/Models/User.cs
+++ b/AsyncAcademy/Models/User.cs
@@ -80,7 +80,8 @@ public class User
 
     [DataType(DataType.PhoneNumber)]
     [Display(Name = "Phone")]
-    [RegularExpression(@"^(0)(/d{9})$", ErrorMessage = "Phone Number must be 10 Digits Long.")]
+    // Phone number should be exactly 10 digits
+    [RegularExpression(@"^\d{10}$", ErrorMessage = "Phone Number must be 10 digits long.")]
     public required string? Phone { get; set; }
 
 


### PR DESCRIPTION
## Summary
- correct the phone number regex in `User`

## Testing
- `dotnet test AsyncAcademy/AsyncAcademy.sln` *(fails: GradesOnGraphAreCorrect, InstructorCanGradeTextEntryTest)*

------
https://chatgpt.com/codex/tasks/task_e_6840d33d3e8083338367f36396e6990e