### PR TITLE
Fix typos in enrollment and tuition tests

### DIFF
--- a/AsyncAcademyTest/UnitTestStudentEnrollment.cs
+++ b/AsyncAcademyTest/UnitTestStudentEnrollment.cs
@@ -174,9 +174,9 @@ namespace AsyncAcademyTest
 
                 //We create the enrollment model and simulate the enrollment process:
                 var pageModel = CreateTestEnrollment(context, courseId, studentId);
-                var result = await pageModel.OnPostAsync(courseId);//Here's where the actuall enrollment happens
+                var result = await pageModel.OnPostAsync(courseId);//Here's where the actual enrollment happens
 
-                //Verify that the rnollment was successful:
+                //Verify that the enrollment was successful:
                 Assert.IsInstanceOfType(result, typeof(RedirectToPageResult), "Enrollment should redirect on success");
                 await VerifyEnrollment(context, studentId, courseId);
             }

--- a/AsyncAcademyTest/UnitTestStudentTuitionIsUpdated.cs
+++ b/AsyncAcademyTest/UnitTestStudentTuitionIsUpdated.cs
@@ -209,7 +209,7 @@ namespace AsyncAcademyTest
 
                 // Enroll the student in a course (for calculating tuition)
                 var pageModel = CreateTestEnrollment(context, courseId, studentId);
-                var result = await pageModel.OnPostAsync(courseId);//Here's where the actuall enrollment happens
+                var result = await pageModel.OnPostAsync(courseId);//Here's where the actual enrollment happens
 
 
 
@@ -224,8 +224,8 @@ namespace AsyncAcademyTest
                 await accountModel.OnGetAsync();  // Assuming this triggers the balance calculation
 
 
-                /*------------For debbuging purposes only: ------------------*/
-                //Verify that the rnollment was successful:
+                /*------------For debugging purposes only: ------------------*/
+                //Verify that the enrollment was successful:
                 //Assert.IsInstanceOfType(result, typeof(RedirectToPageResult), "Enrollment should redirect on success");
                 //await VerifyEnrollment(context, studentId, courseId);
                 /*-----------------------------------------*/


### PR DESCRIPTION
## Summary
- correct enrollment comments in Student Enrollment test
- correct enrollment and debugging comments in Student Tuition test

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d6afb3708333ab8c85156ee3be86