### PR TITLE
Fix signup payment creation order

### DIFF
--- a/AsyncAcademy/Pages/signup.cshtml.cs
+++ b/AsyncAcademy/Pages/signup.cshtml.cs
@@ -44,21 +44,26 @@ namespace AsyncAcademy.Pages
                 return Page();
             }
 
-            if (!Account.IsProfessor)  // Only for students -> We will create an entry in StudenyPayment table
+            // First add the user so EF Core assigns an Id which can be used as
+            // the foreign key for the initial payment record.
+            _context.Users.Add(Account);
+            await _context.SaveChangesAsync();
+
+            // After SaveChangesAsync the Account.Id property will be populated
+            // with the generated key. Only then create the initial Payment
+            // record for students.
+            if (!Account.IsProfessor)
             {
                 var newStudentPayment = new Payment
                 {
-                    UserId = Account.Id,    
-                    AmountPaid = 0,          // No classes signed up yet 
+                    UserId = Account.Id,
+                    AmountPaid = 0,          // No classes signed up yet
                     Timestamp = DateTime.Now
                 };
 
                 _context.Payments.Add(newStudentPayment);
                 await _context.SaveChangesAsync();
             }
-
-            _context.Users.Add(Account);
-            await _context.SaveChangesAsync();
 
             HttpContext.Session.SetInt32("CurrentUserId", Account.Id);
             return RedirectToPage("./welcome");


### PR DESCRIPTION
## Summary
- ensure the user is persisted before creating the associated payment

## Testing
- `dotnet test AsyncAcademy/AsyncAcademy.sln` *(fails: GradesOnGraphAreCorrect, InstructorCanGradeTextEntryTest)*

------
https://chatgpt.com/codex/tasks/task_e_6840d69b3a408333bde7bf65f4fd3fe3